### PR TITLE
Remove unused import in test

### DIFF
--- a/platform/src/test/kotlin/researchstack/backend/adapter/incoming/rest/study/StudyRestControllerTest.kt
+++ b/platform/src/test/kotlin/researchstack/backend/adapter/incoming/rest/study/StudyRestControllerTest.kt
@@ -25,7 +25,6 @@ import researchstack.backend.application.port.incoming.study.DeleteStudyUseCase
 import researchstack.backend.application.port.incoming.study.GetStudyUseCase
 import researchstack.backend.application.port.incoming.study.UpdateStudyUseCase
 import researchstack.backend.config.getUserId
-import researchstack.backend.domain.study.HealthDataGroup
 import java.nio.charset.Charset
 import kotlin.test.assertEquals
 


### PR DESCRIPTION
To fix below lint error, just run `./gradlew ktlintFormat`.

```
./gradlew build                        

> Task :platform:ktlintTestSourceSetCheck FAILED
/home/deokjinkim/backend-system/platform/src/test/kotlin/researchstack/backend/adapter/incoming/rest/study/StudyRestControllerTest.kt:28:1 Unused import

FAILURE: Build failed with an exception.

* What went wrong:
Execution failed for task ':platform:ktlintTestSourceSetCheck'.
> A failure occurred while executing org.jlleitschuh.gradle.ktlint.worker.ConsoleReportWorkAction
   > KtLint found code style violations. Please see the following reports:
     - /home/deokjinkim/Project/2024_health/backend-system/platform/build/reports/ktlint/ktlintTestSourceSetCheck/ktlintTestSourceSetCheck.txt

* Try:
> Run with --stacktrace option to get the stack trace.
> Run with --info or --debug option to get more log output.
> Run with --scan to get full insights.

* Get more help at https://help.gradle.org

BUILD FAILED in 13s
```